### PR TITLE
shorten import path

### DIFF
--- a/barkwire/src/components/DogList.js
+++ b/barkwire/src/components/DogList.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Link } from 'react-router-dom';
 
-import Dog from '../components/Dog';
+import Dog from './Dog';
 
 const DogList = ({ dogs }) => (
   <ul className="dogs">


### PR DESCRIPTION
we are already in the `components` folder,
no need for `../components`